### PR TITLE
expand angular group for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
       angular:
         patterns:
           - "@angular*"
+          - "rxjs"
+          - "zone.js"
       api:
         patterns:
           - "@buf*"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.4 # TODO(jhorsts): unpin when https://github.com/nodejs/node/issues/53902 is resolved
       - name: Setup yarn
         run: corepack enable
       - name: Dependencies


### PR DESCRIPTION
Also, pin node version to 22.4 until nodejs/node#53902 is fixed