### PR TITLE
Use latest node 22.5.1 in GitHub Actions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.4 # TODO(jhorsts): unpin when https://github.com/nodejs/node/issues/53902 is resolved
+          node-version: 22.5.1
       - name: Setup yarn
         run: corepack enable
       - name: Dependencies


### PR DESCRIPTION
The upgrade was blocked by nodejs/node#53902